### PR TITLE
zsh: fix claude() wrapper failing to exec

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -48,7 +48,7 @@ fi
 # globally for that purpose, but if something upstream sets it, drop it for
 # claude only).
 claude() {
-  env -u DO_NOT_TRACK command claude "$@"
+  env -u DO_NOT_TRACK claude "$@"
 }
 
 # OS-specific


### PR DESCRIPTION
`env` is external, so `command` (a shell builtin with no binary on
PATH) couldn't be exec'd — the wrapper errored out instead of running
claude. Drop `command`; env's own PATH lookup finds the real binary
without re-entering the function.