### PR TITLE
tmux: mobile-friendly status, action menu, harmonized keys

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -29,7 +29,7 @@ set -g status-interval 5
 
 # Action menu — opens via [≡] button or `prefix Space` (was: next-layout).
 # display-menu is built-in; single-tap or single-key per row.
-bind Space display-menu -T '#[align=centre,bold] tmux ' -x C -y C \
+bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
   '  + TAB    '  t   new-window \
   '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
   '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \
@@ -42,7 +42,7 @@ bind Space display-menu -T '#[align=centre,bold] tmux ' -x C -y C \
 
 bind -T root MouseUp1Status {
   if -F '#{==:#{mouse_status_range},menu}' {
-    display-menu -T '#[align=centre,bold] tmux ' -x M -y S \
+    display-menu -O -T '#[align=centre,bold] tmux ' -x M -y S \
       '  + TAB    '  t   new-window \
       '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
       '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -43,7 +43,8 @@ bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
 bind -T root MouseUp1Status {
   if -F '#{==:#{mouse_status_range},menu}' {
     # No -O here: on mobile, a tap *is* a release; -O would swallow it.
-    display-menu -T '#[align=centre,bold] tmux ' -x M -y S \
+    # -y M (not S) anchors the menu at the click so the cursor starts inside it.
+    display-menu -T '#[align=centre,bold] tmux ' -x M -y M \
       '  + TAB    '  t   new-window \
       '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
       '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -42,7 +42,8 @@ bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
 
 bind -T root MouseUp1Status {
   if -F '#{==:#{mouse_status_range},menu}' {
-    display-menu -O -T '#[align=centre,bold] tmux ' -x M -y S \
+    # No -O here: on mobile, a tap *is* a release; -O would swallow it.
+    display-menu -T '#[align=centre,bold] tmux ' -x M -y S \
       '  + TAB    '  t   new-window \
       '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
       '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -23,8 +23,8 @@ set -g status-fg green
 set -g status-right "#[range=user|menu,bg=green,fg=black] [≡] #[norange] #{tmux_mode_indicator}"
 
 # Tab-like window list (clickable with mouse on)
-setw -g window-status-format         ' #I:#W '
-setw -g window-status-current-format '#[bold] #I:#W '
+setw -g window-status-format         ' #I:#W#{?window_zoomed_flag,#[bg=yellow;fg=black] Z #[default],} '
+setw -g window-status-current-format '#[bold] #I:#W#{?window_zoomed_flag,#[bg=yellow;fg=black;nobold] Z #[default;bold],} '
 set -g status-interval 5
 
 # Action menu — opens via [≡] button or `prefix Space` (was: next-layout).

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -20,6 +20,33 @@ bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
 set -g status-bg black
 set -g status-fg green
 set -g status-right "#{tmux_mode_indicator}"
+
+# Tab-like window list (clickable with mouse on)
+setw -g window-status-format         ' #I:#W '
+setw -g window-status-current-format '#[bold] #I:#W '
+set -g status-interval 5
+
+# Touch toolbar — second status row with big tap targets (mobile-friendly).
+# Row 0 keeps the window list; row 1 is the toolbar.
+set -g status 2
+set -g status-format[1] '#[align=left,bg=black,fg=green]\
+ #[range=user|new,bg=green,fg=black]  + TAB  #[norange]\
+ #[range=user|sph,bg=green,fg=black]  | SPLIT  #[norange]\
+ #[range=user|spv,bg=green,fg=black]  - SPLIT  #[norange]\
+ #[range=user|prev,bg=green,fg=black]  < PREV  #[norange]\
+ #[range=user|next,bg=green,fg=black]  NEXT >  #[norange]\
+ #[range=user|zoom,bg=green,fg=black]  ZOOM  #[norange]\
+ #[range=user|kill,bg=red,fg=white]  X KILL  #[norange]'
+
+bind -T root MouseUp1Status {
+  if -F '#{==:#{mouse_status_range},new}'  { new-window }
+  if -F '#{==:#{mouse_status_range},sph}'  { split-window -h -c "#{pane_current_path}" }
+  if -F '#{==:#{mouse_status_range},spv}'  { split-window -v -c "#{pane_current_path}" }
+  if -F '#{==:#{mouse_status_range},prev}' { previous-window }
+  if -F '#{==:#{mouse_status_range},next}' { next-window }
+  if -F '#{==:#{mouse_status_range},zoom}' { resize-pane -Z }
+  if -F '#{==:#{mouse_status_range},kill}' { confirm-before -p 'kill pane? (y/n) ' kill-pane }
+}
  
 # Window numbering starts at 1 to match keyboard
 set -g base-index 1
@@ -46,6 +73,8 @@ set -g @mode_indicator_sync_prompt ' SYNC '
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'MunifTanjim/tmux-mode-indicator'
+set -g @plugin 'jaclu/tmux-menus'
+# Trigger: prefix + \ (plugin default). Works in mosh / Blink.
  
 # Initialize plugin manager (keep at bottom)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -27,6 +27,13 @@ setw -g window-status-format         ' #I:#W#{?window_zoomed_flag,#[bg=yellow;fg
 setw -g window-status-current-format '#[bold] #I:#W#{?window_zoomed_flag,#[bg=yellow;fg=black;nobold] Z #[default;bold],} '
 set -g status-interval 5
 
+# Direct shortcuts mirroring the action menu's single-key labels, so
+# muscle memory transfers: `prefix |` ≡ `prefix Space |`.
+# (p, n, z, x already match tmux defaults — no rebind needed.)
+bind '|' split-window -h -c "#{pane_current_path}"
+bind '-' split-window -v -c "#{pane_current_path}"
+bind  t  new-window                 # default was clock-mode
+
 # Action menu — two triggers, two flag sets (deliberately asymmetric):
 #   prefix Space (desktop): -O so cursor motion doesn't dismiss the menu.
 #   [≡] tap (mobile):       no -O, since on mobile a tap *is* a release
@@ -42,7 +49,7 @@ bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
   '  NEXT >   '  n   next-window \
   '  ZOOM     '  z   'resize-pane -Z' \
   '' \
-  '  X KILL   '  K   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
+  '  X KILL   '  x   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
 
 bind -T root MouseUp1Status {
   if -F '#{==:#{mouse_status_range},menu}' {
@@ -56,7 +63,7 @@ bind -T root MouseUp1Status {
       '  NEXT >   '  n   next-window \
       '  ZOOM     '  z   'resize-pane -Z' \
       '' \
-      '  X KILL   '  K   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
+      '  X KILL   '  x   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
   }
 }
  

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -27,8 +27,12 @@ setw -g window-status-format         ' #I:#W#{?window_zoomed_flag,#[bg=yellow;fg
 setw -g window-status-current-format '#[bold] #I:#W#{?window_zoomed_flag,#[bg=yellow;fg=black;nobold] Z #[default;bold],} '
 set -g status-interval 5
 
-# Action menu — opens via [≡] button or `prefix Space` (was: next-layout).
-# display-menu is built-in; single-tap or single-key per row.
+# Action menu — two triggers, two flag sets (deliberately asymmetric):
+#   prefix Space (desktop): -O so cursor motion doesn't dismiss the menu.
+#   [≡] tap (mobile):       no -O, since on mobile a tap *is* a release
+#                           and -O would swallow it as a selection.
+# Side effect: clicking [≡] with a desktop pointer is a bit flaky;
+# the keybind is the desktop path. (`prefix Space` was: next-layout.)
 bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
   '  + TAB    '  t   new-window \
   '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
@@ -42,8 +46,7 @@ bind Space display-menu -O -T '#[align=centre,bold] tmux ' -x C -y C \
 
 bind -T root MouseUp1Status {
   if -F '#{==:#{mouse_status_range},menu}' {
-    # No -O here: on mobile, a tap *is* a release; -O would swallow it.
-    # -y M (not S) anchors the menu at the click so the cursor starts inside it.
+    # See note on `bind Space` above for the no-O / -y M reasoning.
     display-menu -T '#[align=centre,bold] tmux ' -x M -y M \
       '  + TAB    '  t   new-window \
       '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -19,33 +19,40 @@ bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
 # Status bar
 set -g status-bg black
 set -g status-fg green
-set -g status-right "#{tmux_mode_indicator}"
+# Right side: tappable [≡] menu button + mode indicator
+set -g status-right "#[range=user|menu,bg=green,fg=black] [≡] #[norange] #{tmux_mode_indicator}"
 
 # Tab-like window list (clickable with mouse on)
 setw -g window-status-format         ' #I:#W '
 setw -g window-status-current-format '#[bold] #I:#W '
 set -g status-interval 5
 
-# Touch toolbar — second status row with big tap targets (mobile-friendly).
-# Row 0 keeps the window list; row 1 is the toolbar.
-set -g status 2
-set -g status-format[1] '#[align=left,bg=black,fg=green]\
- #[range=user|new,bg=green,fg=black]  + TAB  #[norange]\
- #[range=user|sph,bg=green,fg=black]  | SPLIT  #[norange]\
- #[range=user|spv,bg=green,fg=black]  - SPLIT  #[norange]\
- #[range=user|prev,bg=green,fg=black]  < PREV  #[norange]\
- #[range=user|next,bg=green,fg=black]  NEXT >  #[norange]\
- #[range=user|zoom,bg=green,fg=black]  ZOOM  #[norange]\
- #[range=user|kill,bg=red,fg=white]  X KILL  #[norange]'
+# Action menu — opens via [≡] button or `prefix Space` (was: next-layout).
+# display-menu is built-in; single-tap or single-key per row.
+bind Space display-menu -T '#[align=centre,bold] tmux ' -x C -y C \
+  '  + TAB    '  t   new-window \
+  '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
+  '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \
+  '' \
+  '  < PREV   '  p   previous-window \
+  '  NEXT >   '  n   next-window \
+  '  ZOOM     '  z   'resize-pane -Z' \
+  '' \
+  '  X KILL   '  K   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
 
 bind -T root MouseUp1Status {
-  if -F '#{==:#{mouse_status_range},new}'  { new-window }
-  if -F '#{==:#{mouse_status_range},sph}'  { split-window -h -c "#{pane_current_path}" }
-  if -F '#{==:#{mouse_status_range},spv}'  { split-window -v -c "#{pane_current_path}" }
-  if -F '#{==:#{mouse_status_range},prev}' { previous-window }
-  if -F '#{==:#{mouse_status_range},next}' { next-window }
-  if -F '#{==:#{mouse_status_range},zoom}' { resize-pane -Z }
-  if -F '#{==:#{mouse_status_range},kill}' { confirm-before -p 'kill pane? (y/n) ' kill-pane }
+  if -F '#{==:#{mouse_status_range},menu}' {
+    display-menu -T '#[align=centre,bold] tmux ' -x M -y S \
+      '  + TAB    '  t   new-window \
+      '  | SPLIT  '  '|' 'split-window -h -c "#{pane_current_path}"' \
+      '  - SPLIT  '  '-' 'split-window -v -c "#{pane_current_path}"' \
+      '' \
+      '  < PREV   '  p   previous-window \
+      '  NEXT >   '  n   next-window \
+      '  ZOOM     '  z   'resize-pane -Z' \
+      '' \
+      '  X KILL   '  K   "confirm-before -p 'kill pane? (y/n) ' kill-pane"
+  }
 }
  
 # Window numbering starts at 1 to match keyboard


### PR DESCRIPTION
## Summary

Make tmux usable from Blink + mosh + iOS, where iTerm2's `-CC` mode isn't available, without compromising the desktop experience.

- **Action menu via `display-menu`** — opens via `prefix Space` (desktop) or a clickable `[≡]` hotspot in `status-right` (mobile). Single-tap / single-key for: new tab, split-h, split-v, prev, next, zoom, kill.
- **Asymmetric `-O` flag** — `prefix Space` uses `-O` so cursor motion doesn't dismiss; the tap-triggered menu omits `-O` so a mobile tap-release registers as a selection. Documented in-file.
- **Direct prefix shortcuts mirror the menu** — `prefix |`, `prefix -`, `prefix t` so muscle memory transfers between `prefix Space x` and `prefix x`.
- **Zoom indicator** — yellow `Z` badge on the active window's status entry when a pane is zoomed.
- **Tab-style window list** — clickable in mouse mode.
- **`jaclu/tmux-menus`** plugin added as a fuller menu fallback (`prefix \`).

Iterated through a couple of design dead-ends (two-row toolbar; symmetric `-O`); commit history walks through the reasoning.

## Test plan

- [ ] Reload on local Mac (`prefix R`); `[≡]` opens menu, `prefix Space` opens menu, `prefix |` splits, zoom shows `Z` badge.
- [ ] Reload on toothless via mosh; same checks.
- [ ] Mobile (Blink + mosh + tmux on toothless): tap `[≡]`, tap a menu item, confirm action fires.