### PR TITLE
tmux: add tmux-fzf for fuzzy command palette (prefix F)

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -94,6 +94,10 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'MunifTanjim/tmux-mode-indicator'
 set -g @plugin 'jaclu/tmux-menus'
 # Trigger: prefix + \ (plugin default). Works in mosh / Blink.
+
+# Fuzzy command palette — `prefix F` opens fzf over sessions/windows/
+# panes/keybinds/commands. Requires fzf on PATH (server-side under mosh).
+set -g @plugin 'sainnhe/tmux-fzf'
  
 # Initialize plugin manager (keep at bottom)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -98,6 +98,10 @@ set -g @plugin 'jaclu/tmux-menus'
 # Fuzzy command palette — `prefix F` opens fzf over sessions/windows/
 # panes/keybinds/commands. Requires fzf on PATH (server-side under mosh).
 set -g @plugin 'sainnhe/tmux-fzf'
+
+# Override `prefix ?` (was: paged `list-keys -N`) with tmux-fzf's
+# searchable keybinding view — better for learning bindings.
+bind ? run-shell -b ~/.tmux/plugins/tmux-fzf/scripts/keybinding.sh
  
 # Initialize plugin manager (keep at bottom)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -98,10 +98,6 @@ set -g @plugin 'jaclu/tmux-menus'
 # Fuzzy command palette — `prefix F` opens fzf over sessions/windows/
 # panes/keybinds/commands. Requires fzf on PATH (server-side under mosh).
 set -g @plugin 'sainnhe/tmux-fzf'
-
-# Override `prefix ?` (was: paged `list-keys -N`) with tmux-fzf's
-# searchable keybinding view — better for learning bindings.
-bind ? run-shell -b ~/.tmux/plugins/tmux-fzf/scripts/keybinding.sh
  
 # Initialize plugin manager (keep at bottom)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

Adds `sainnhe/tmux-fzf` so `prefix F` opens an fzf popup over sessions, windows, panes, keybinds, and tmux commands — VS Code Cmd-P style. Helps with the "I can never remember tmux bindings" problem by making everything searchable.

**Stacked on** #3 — both PRs touch the plugins block, so this targets `tmux-mobile-friendly` to avoid conflicts. Rebase to `main` after #3 merges.

**Requires** fzf on PATH (server-side under mosh).

## Test plan

- [ ] `prefix F` opens an fzf popup
- [ ] Search for a session/window/pane/keybind, Enter to select
- [ ] Works under mosh on toothless (assumes `apt install fzf` first)